### PR TITLE
Start counter and select number state

### DIFF
--- a/GAME.asm
+++ b/GAME.asm
@@ -60,19 +60,21 @@ POLL1       bit.b   #04h, &P2IN             ; Poll Button B1 until pressed
                                             ; Active high or Active low
 
 ;------------------------------------------------------------------------------
-;                   Choose Difficulty Level
+;                   Choose Difficulty Level State
 ;------------------------------------------------------------------------------
 ;                   R4 = Difficulty Level
 ;                   4 - Basic
 ;                   2 - Intermediate
-;                   0 - Advanced
+;                   1 - Advanced
 ;------------------------------------------------------------------------------
             mov     #MSGDIFF, R13           ; Load Cstring of difficulty message
             call    #WRITEMSG               ; Write message
+
             call    #DELAY500M              ; Wait ~2 seconds to show message
             call    #DELAY500M              ;
             call    #DELAY500M              ;
             call    #DELAY500M              ;
+
             mov.b   #01h, R14               ; Load command Clear Display
             call    #COMMANDLCD             ; Send command to Clear Display
             call    #DELAY15M               ; Wait until LCD is stable
@@ -81,7 +83,7 @@ POLL1       bit.b   #04h, &P2IN             ; Poll Button B1 until pressed
             mov     #MSGOPTION, R13         ; Load Cstring of option message
             call    #WRITESTR               ; Write string in 2nd line
 
-LOOPAGAIN   mov.b   #04h, R4                ; Start assuming difficulty = 2
+LOOPAGAIN   mov.b   #04h, R4                ; Start assuming difficulty = 4
 ASKNEXTDIFF mov     WHICHDIFF(R4), R13      ; Load Cstring of currently
                                             ; assumed difficulty message
             mov.b   #080h, R14              ; Load command to move cursor 1st LN
@@ -101,12 +103,71 @@ POLL2       bit.b   #04h, &P2IN             ; Poll Button 1
             jnc     ASKNEXTDIFF             ; Ask for next difficulty
             jmp     LOOPAGAIN
 
-DIFFCHOSEN                                  ; Finished Decision Making
+DIFFCHOSEN  call    #DELAY500M              ; For debouncing
+                                            ; Finished Decision Making
+;------------------------------------------------------------------------------
+;                   Set initial Level to 1
+;------------------------------------------------------------------------------
+;                   R5  = Level
+;                   1   - TRANSISTOR
+;                   2   - NAND
+;                   4   - FLIP/FLOP
+;                   8   - REGISTER
+;                   16  - COUNTER
+;                   32  - ALU
+;                   64  - CPU
+;                   128 - MCU
+;------------------------------------------------------------------------------
+            mov.b   #01h, R5                ; Set initial level to 1
+
+;------------------------------------------------------------------------------
+;****************** Start MainLoop ********************************************
+;------------------------------------------------------------------------------
+MAINLOOP    mov.b   #01h, R14               ; Load command Clear Display
+            call    #COMMANDLCD             ; Send command to Clear Display
+            call    #DELAY15M               ; Wait until LCD is stable
+
+;------------------------------------------------------------------------------
+;                   Show Current Level
+;------------------------------------------------------------------------------
+            mov     #MSGLVL, R13            ; Load Cstring of level message
+            call    #WRITESTR               ; Write string in 1st line
+            mov.b   #0A8h, R14              ; Load command to move cursor 2nd LN
+            call    #COMMANDLCD             ; Send command to move cursor 2nd LN
+            mov     WHICHLVL(R5), R13       ; Load Cstring of current
+                                            ; level message
+            call    #WRITESTR               ; Write string in 2nd line
+
+            call    #DELAY500M              ; Wait ~2 seconds to show message
+            call    #DELAY500M              ;
+            call    #DELAY500M              ;
+            call    #DELAY500M              ;
+
+;------------------------------------------------------------------------------
+;                   Start Counter and Select Number State
+;------------------------------------------------------------------------------
+            mov.b   #01h, R14               ; Load command Clear Display
+            call    #COMMANDLCD             ; Send command to Clear Display
+            call    #DELAY15M               ; Wait until LCD is stable
+
+            mov     #MSGINSTR, R13          ; Load Cstring of instruct message
+            call    #WRITEMSG               ; Write message
+            call    #DELAY500M              ; Wait ~2 seconds to show message
+            call    #DELAY500M              ;
+            call    #DELAY500M              ;
+            call    #DELAY500M              ;
+
+            mov.b   #01h, R14               ; Load command Clear Display
+            call    #COMMANDLCD             ; Send command to Clear Display
+            call    #DELAY15M               ; Wait until LCD is stable
+
+            mov     #MSGNUMBS, R13          ; Load Cstring of numbers message
+            call    #WRITESTR               ; Write string in 1st line
 
 HERE        jmp     HERE
 
 ;------------------------------------------------------------------------------
-;                   LCD - Write 1 line string Message in the second line
+;                   LCD - Write 1 line string Message
 ;------------------------------------------------------------------------------
 ;                   R13 = Pointer to message Cstring
 ;                   R14 = COMMAND/CHARACTER
@@ -227,6 +288,8 @@ DELAY160UA  dec     R15                     ; Decrement number of iterations
 ;                   Switch Statements
 ;------------------------------------------------------------------------------
 WHICHDIFF   DW      MSGADVAN, MSGINTER, MSGBASIC
+WHICHLVL    DW      MSGLV0, MSGLV1, MSGLV2, MSGLV3, MSGLV4, MSGLV5, MSGLV6
+            DW      MSGLV7
 
 ;------------------------------------------------------------------------------
 ;                   Static Messages - Cstring
@@ -237,6 +300,17 @@ MSGOPTION   DB      "Si=B1      No=B2"
 MSGBASIC    DB      "     Basico     "
 MSGINTER    DB      "   Intermedio   "
 MSGADVAN    DB      "    Avanzado    "
+MSGINSTR    DB      "Presiona B1", "Para Detener"
+MSGNUMBS    DB      "0123456789ABCDEF"
+MSGLVL      DB      "Esta en Nivel"
+MSGLV0      DB      "0 - TRANSISTOR"
+MSGLV1      DB      "1 - NAND"
+MSGLV2      DB      "2 - FLIP/FLOP"
+MSGLV3      DB      "3 - REGISTER"
+MSGLV4      DB      "4 - COUNTER"
+MSGLV5      DB      "5 - ALU"
+MSGLV6      DB      "6 - CPU"
+MSGLV7      DB      "7 - MCU"
 MSGUP       DB      "Avanza al", "Proximo Nivel"
 MSGDOWN     DB      "Baja de Nivel", " "
 MSGWON      DB      "Felicidades! :)", "Usted ha Ganado"

--- a/Tasks.txt
+++ b/Tasks.txt
@@ -32,8 +32,17 @@ Game Logic Tasks / States:
         + 500ms delay
 - Start Counter and Select Number State
     - Add more Static messages to call with previously implemented subroutines
-        -"Presiona B1 Para Detener"
-        - "0123456789ABCDEF"
+        + "Presiona B1 Para Detener"
+        + "0123456789ABCDEF"
+        + "Esta en Nivel"
+        + "0 - TRANSISTOR"
+        + "1 - NAND"
+        + "2 - FLIP/FLOP"
+        + "3 - REGISTER"
+        + "4 - COUNTER"
+        + "5 - ALU"
+        + "6 - CPU"
+        + "7 - MCU"
     - Implement delays
         - 100ms
         - 200ms
@@ -47,5 +56,5 @@ ________________________________________________________________________________
 R15     | Delay subroutines                     | Used as a counter
 R14     | Subroutines COMMANDLCD and WRITELCD   | Used to pass value to subroutine
 R13     | Subroutine WRITESTR and WRITEMSG      | Used to pass value and as Iterator
-R4      | Throughout the game                   | Holds the value of difficulty
-
+R4      | Throughout the game (Stays the same)  | Holds the value of difficulty
+R5      | Throughout the game (Changes)         | Holds the value of selected number

--- a/Tasks.txt
+++ b/Tasks.txt
@@ -22,15 +22,22 @@ LCD Tasks:
 
 Game Logic Tasks / States:
 + Choose Difficulty State
-    + Add more Static messages to call with previously implemented subroutine
+    + Add more Static messages to call with previously implemented subroutines
         + "Escoja Modo de Operacion"
-        + "     Basico     ", "Si=B1      No=B2"
-        + "   Intermedio   ", "Si=B1      No=B2"
-        + "    Avanzado    ", "Si=B1      No=B2"
+        + "Si=B1      No=B2"
+        + "     Basico     "
+        + "   Intermedio   "
+        + "    Avanzado    "
     + Implement longer delay for debouncing
         + 500ms delay
-- Start counter and Select Number State
-
+- Start Counter and Select Number State
+    - Add more Static messages to call with previously implemented subroutines
+        -"Presiona B1 Para Detener"
+        - "0123456789ABCDEF"
+    - Implement delays
+        - 100ms
+        - 200ms
+        - 400ms
 
 
 Registers:

--- a/Tasks.txt
+++ b/Tasks.txt
@@ -30,8 +30,8 @@ Game Logic Tasks / States:
         + "    Avanzado    "
     + Implement longer delay for debouncing
         + 500ms delay
-- Start Counter and Select Number State
-    - Add more Static messages to call with previously implemented subroutines
++ Start Counter and Select Number State
+    + Add more Static messages to call with previously implemented subroutines
         + "Presiona B1 Para Detener"
         + "0123456789ABCDEF"
         + "Esta en Nivel"
@@ -44,17 +44,17 @@ Game Logic Tasks / States:
         + "6 - CPU"
         + "7 - MCU"
         + "^"   PIVOT
-    - Implement delays
-        - 100ms
-        - 200ms
-        - 400ms
+    + Implement delays
+        + 100ms
+        + 200ms
+        + 400ms
 + Changed Delay implementation. Now it uses internal Timer.
 
 Registers:
 
 NAME    | WHERE                                 | Description
 __________________________________________________________________________________
-R15     | Delay subroutines                     | Used as a counter
+R15     | Throughout the game (Changes)         | Value of chosen number
 R14     | Subroutines COMMANDLCD and WRITELCD   | Used to pass value to subroutine
 R13     | Subroutine WRITESTR and WRITEMSG      | Used to pass value and as Iterator
 R4      | Throughout the game (Stays the same)  | Holds the value of difficulty

--- a/Tasks.txt
+++ b/Tasks.txt
@@ -43,11 +43,12 @@ Game Logic Tasks / States:
         + "5 - ALU"
         + "6 - CPU"
         + "7 - MCU"
+        + "^"   PIVOT
     - Implement delays
         - 100ms
         - 200ms
         - 400ms
-
++ Changed Delay implementation. Now it uses internal Timer.
 
 Registers:
 


### PR DESCRIPTION
Updated the list. Delay is implemented using Timer TA0 and called by a MACRO called delay. Added more delay time at the end of the subroutines WRITELCD and COMMANDLCD. Changed R15 duty, now it will hold the value chosen after this State. Future improvements: Changed all Polling I/O to Interrupts.
